### PR TITLE
Friendlier KAFKA_TOPIC

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,12 @@ Create the sample topic, by default the topic will have 32 partitions.
 $ heroku kafka:create messages
 ```
 
+Set an environment variable referencing the new topic:
+
+```
+$ heroku config:set KAFKA_TOPIC=messages
+```
+
 Deploy to Heroku and open the app:
 
 ```

--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,6 @@ logging:
 
   loggers:
     com.heroku.kafka.demo: DEBUG
+
+kafkaConfig:
+  topic: ${KAFKA_TOPIC}

--- a/config.yml
+++ b/config.yml
@@ -4,5 +4,5 @@ logging:
   loggers:
     com.heroku.kafka.demo: DEBUG
 
-kafkaConfig:
+kafka:
   topic: ${KAFKA_TOPIC}

--- a/src/main/java/com/heroku/kafka/demo/DemoApplication.java
+++ b/src/main/java/com/heroku/kafka/demo/DemoApplication.java
@@ -3,6 +3,8 @@ package com.heroku.kafka.demo;
 import com.codahale.metrics.Slf4jReporter;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
@@ -28,6 +30,11 @@ public class DemoApplication extends Application<DemoConfiguration>  {
   public void initialize(Bootstrap<DemoConfiguration> bootstrap) {
     bootstrap.addBundle(new ViewBundle<>());
     bootstrap.addBundle(new AssetsBundle());
+    bootstrap.setConfigurationSourceProvider(
+            new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
+                    new EnvironmentVariableSubstitutor()
+            )
+    );
   }
 
   @Override

--- a/src/main/java/com/heroku/kafka/demo/DemoConfiguration.java
+++ b/src/main/java/com/heroku/kafka/demo/DemoConfiguration.java
@@ -1,5 +1,6 @@
 package com.heroku.kafka.demo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.loginbox.heroku.config.HerokuConfiguration;
 
 import javax.validation.Valid;
@@ -7,6 +8,7 @@ import javax.validation.Valid;
 public class DemoConfiguration extends HerokuConfiguration {
 
   @Valid
+  @JsonProperty("kafka")
   private final KafkaConfig kafkaConfig = new KafkaConfig();
 
   public KafkaConfig getKafkaConfig() {

--- a/src/main/java/com/heroku/kafka/demo/DemoConfiguration.java
+++ b/src/main/java/com/heroku/kafka/demo/DemoConfiguration.java
@@ -2,7 +2,11 @@ package com.heroku.kafka.demo;
 
 import com.loginbox.heroku.config.HerokuConfiguration;
 
+import javax.validation.Valid;
+
 public class DemoConfiguration extends HerokuConfiguration {
+
+  @Valid
   private final KafkaConfig kafkaConfig = new KafkaConfig();
 
   public KafkaConfig getKafkaConfig() {

--- a/src/main/java/com/heroku/kafka/demo/KafkaConfig.java
+++ b/src/main/java/com/heroku/kafka/demo/KafkaConfig.java
@@ -6,6 +6,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SslConfigs;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import java.io.File;
 import java.net.URI;
@@ -18,6 +19,10 @@ import static java.lang.String.format;
 import static java.lang.System.getenv;
 
 public class KafkaConfig {
+
+  @NotEmpty
+  private String topic;
+
   public Properties getProperties() {
     return buildDefaults();
   }
@@ -68,6 +73,6 @@ public class KafkaConfig {
   }
 
   public String getTopic() {
-    return checkNotNull(getenv("KAFKA_TOPIC"));
+    return topic;
   }
 }


### PR DESCRIPTION
- add instructions to create config var for topic
- blow up on boot if topic env var isn't set (rather than waiting for a POST to the resource)