### PR TITLE
Remove instructions to set `KAFKA_TOPIC` config var

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,12 +27,6 @@ Create the sample topic, by default the topic will have 32 partitions.
 $ heroku kafka:create messages
 ```
 
-Set an environment variable referencing the new topic:
-
-```
-$ heroku config:set KAFKA_TOPIC=messages
-```
-
 Deploy to Heroku and open the app:
 
 ```


### PR DESCRIPTION
- This config var isn’t actually used anymore