### PR TITLE
Update env-keystore and readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,12 @@ This demo app accepts HTTP POST requests and writes them to a topic, and has a s
 
 You'll need to [provision](#provisioning) the app.
 
+## Building
+
+```
+mvn clean compile
+```
+
 ## Provisioning
 
 Install the kafka cli plugin:

--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,7 @@ $ heroku kafka:wait
 Create the sample topic, by default the topic will have 32 partitions.
 
 ```
-$ heroku kafka:create messages
+$ heroku kafka:topics:create messages
 ```
 
 Deploy to Heroku and open the app:

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.github.jkutner</groupId>
       <artifactId>env-keystore</artifactId>
-      <version>0.1.2</version>
+      <version>0.1.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Use env-keystore 0.1.3 which allows multiple certs in a file. Also update out-dated info on readme. I confirmed this works with multiple trusted certs on a test app.