### PR TITLE
chore: add CODEOWNERS owner and maven dependabot config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- What does this change do and why? -->
+
+---
+
+### Relevant links
+
+<!-- Link the related GUS work item. -->
+
+---
+
+### Type of change
+
+<!-- New feature / Bug fix / Refactor / Hotfix / Documentation / Chore -->
+
+---
+
+### Backout plan
+
+Revert the change and deploy.
+
+---
+
+## Testing
+
+<!-- Describe how this was tested, or why testing is not applicable. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 1
+    labels:
+      - "dependencies"
+    groups:
+      version-updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      security-updates:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+* @heroku/data


### PR DESCRIPTION
## Description

This repo had a CODEOWNERS file with only comment lines (an ECCN header) and no actual owner rule, so GitHub treated it as unowned. It also had no Dependabot config.

- Add `* @heroku/data` ownership line (preserving the existing ECCN comment).
- Add a Dependabot config for the `maven` ecosystem (this repo builds via `pom.xml`), modeled on shogun: weekly, grouped version + security updates (minor/patch), `dependencies` label, 1-day cooldown.

No `github-actions` ecosystem block since this repo has no GitHub Actions workflows.

---

### Relevant links

- [W-23923109](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002iAD0QYAW/view)

---

### Type of change

Chore (configuration only)

---

### Backout plan

Revert the change and deploy.

---

## Testing

N/A - configuration only. No runtime code paths are affected.
